### PR TITLE
Qa/issue 38

### DIFF
--- a/src/it/scala/code/service/ProjectServiceTest.scala
+++ b/src/it/scala/code/service/ProjectServiceTest.scala
@@ -2,6 +2,7 @@ package code.service
 
 import code.model.Project
 import code.test.utils.DbSpec
+import net.liftweb.common.Box
 import net.liftweb.mapper.By
 import org.scalatest.{FunSuite, FunSpec}
 
@@ -41,6 +42,30 @@ class ProjectServiceTest extends FunSuite with DbSpec {
     assert(ProjectService.getDisplayName(project("bottom")) == "bottom")
   }
 
+  test("The top level project is not empty") {
+    givenSomeProjectData()
+
+    assert(!ProjectService.isEmpty(project("top")))
+  }
+
+  test("The bottom level project is empty") {
+    givenSomeProjectData()
+
+    assert(ProjectService.isEmpty(project("bottom")))
+  }
+
+  test("Delete a bottom level project") {
+    givenSomeProjectData()
+
+    assert(ProjectService.delete(project("bottom")))
+  }
+
+  test("Try to delete a top level project") {
+    intercept[IllegalArgumentException] {
+      ProjectService.delete(project("top"))
+    }
+  }
+
   def givenSomeProjectData(): Unit = {
     Project.create.name("top").save()
     lazy val top = Project.find(By(Project.name, "top"))
@@ -51,4 +76,5 @@ class ProjectServiceTest extends FunSuite with DbSpec {
   }
   
   def project(n: String): Project = Project.find(By(Project.name, n)).openOrThrowException("Test entity must be presented!")
+
 }

--- a/src/it/scala/code/service/ProjectServiceTest.scala
+++ b/src/it/scala/code/service/ProjectServiceTest.scala
@@ -25,6 +25,22 @@ class ProjectServiceTest extends FunSuite with DbSpec {
     assert(ProjectService.getDisplayName(project("bottom")) == "top-middle-bottom")
   }
 
+  test("Move bottom project to any parent project") {
+    givenSomeProjectData()
+
+    ProjectService.move(project("bottom"), project("any project"))
+
+    assert(ProjectService.getDisplayName(project("bottom")) == "top-any project-bottom")
+  }
+
+  test("Move bottom project to root") {
+    givenSomeProjectData()
+
+    ProjectService.moveToRoot(project("bottom"))
+
+    assert(ProjectService.getDisplayName(project("bottom")) == "bottom")
+  }
+
   def givenSomeProjectData(): Unit = {
     Project.create.name("top").save()
     lazy val top = Project.find(By(Project.name, "top"))

--- a/src/it/scala/code/service/ProjectServiceTest.scala
+++ b/src/it/scala/code/service/ProjectServiceTest.scala
@@ -1,0 +1,38 @@
+package code.service
+
+import code.model.Project
+import code.test.utils.DbSpec
+import net.liftweb.mapper.By
+import org.scalatest.{FunSuite, FunSpec}
+
+class ProjectServiceTest extends FunSuite with DbSpec {
+
+  test("Display name of the top level project") {
+    givenSomeProjectData()
+
+    assert(ProjectService.getDisplayName(project("top")) == "top")
+  }
+
+  test("Display name of the middle level project") {
+    givenSomeProjectData()
+
+    assert(ProjectService.getDisplayName(project("middle")) == "top-middle")
+  }
+
+  test("Display name of the bottom level project") {
+    givenSomeProjectData()
+
+    assert(ProjectService.getDisplayName(project("bottom")) == "top-middle-bottom")
+  }
+
+  def givenSomeProjectData(): Unit = {
+    Project.create.name("top").save()
+    lazy val top = Project.find(By(Project.name, "top"))
+    Project.create.name("any project").parent(top).save()
+    Project.create.name("middle").parent(top).save()
+    lazy val middle = Project.find(By(Project.name, "middle"))
+    Project.create.name("bottom").parent(middle).save()
+  }
+  
+  def project(n: String): Project = Project.find(By(Project.name, n)).openOrThrowException("Test entity must be presented!")
+}

--- a/src/main/scala/code/service/ProjectService.scala
+++ b/src/main/scala/code/service/ProjectService.scala
@@ -8,17 +8,17 @@ import net.liftweb.common.{Box, Full, Empty}
 
 object ProjectService {
 
-  def getDisplayName(project: Project): String = {
-    def loop(z: List[Project], box: Box[Project]): List[Project] = box match {
-      case Full(p) => loop(p :: z, Project.findByKey(p.parent.get))
+  def getDisplayName(p: Project): String = {
+    def path(z: List[Project], box: Box[Project]): List[Project] = box match {
+      case Full(pr) => path(pr :: z, Project.findByKey(pr.parent.get))
       case _ => z
     }
-    loop(Nil, Full(project)).map(_.name).mkString("-")
+    path(Nil, Full(p)).map(_.name).mkString("-")
   }
 
-  def move(what: Project, newParent: Project) = what.parent(newParent).save
+  def move(p: Project, pp: Project) = p.parent(pp).save()
 
-  def moveToRoot(what: Project) = what.parent(Empty).save
+  def moveToRoot(p: Project) = p.parent(Empty).save()
 
   def isEmpty(project: Project) = Task.findAll(By(Task.parent, project)).isEmpty && Project.findAll(By(Project.parent, project)).isEmpty
 

--- a/src/main/scala/code/service/ProjectService.scala
+++ b/src/main/scala/code/service/ProjectService.scala
@@ -20,14 +20,10 @@ object ProjectService {
 
   def moveToRoot(p: Project) = p.parent(Empty).save()
 
-  def isEmpty(project: Project) = Task.findAll(By(Task.parent, project)).isEmpty && Project.findAll(By(Project.parent, project)).isEmpty
+  def isEmpty(p: Project) = Task.findAll(By(Task.parent, p)).isEmpty && Project.findAll(By(Project.parent, p)).isEmpty
 
-  def delete(project: Project) = {
-    if (isEmpty(project)) {
-      project.delete_!
-    } else {
-      throw new IllegalArgumentException("Projects with Tasks or Subprojects can not be deleted.");
-    }
-  }
+  def delete(p: Project) =
+    if (isEmpty(p)) p.delete_!
+    else throw new IllegalArgumentException("Projects with tasks or subprojects can not be deleted.")
 
 }

--- a/src/main/scala/code/service/ProjectService.scala
+++ b/src/main/scala/code/service/ProjectService.scala
@@ -8,22 +8,21 @@ import net.liftweb.common.{Box, Full, Empty}
 
 object ProjectService {
 
-  def getDisplayName(p: Project): String = {
-    def path(z: List[Project], box: Box[Project]): List[Project] = box match {
-      case Full(pr) => path(pr :: z, Project.findByKey(pr.parent.get))
-      case _ => z
-    }
-    path(Nil, Full(p)).map(_.name).mkString("-")
+  def getDisplayName(project: Project): String = projectPath(Nil, Full(project)).map(_.name).mkString("-")
+  
+  private def projectPath(z: List[Project], project: Box[Project]): List[Project] = project match {
+    case Full(p) => projectPath(p :: z, Project.findByKey(p.parent.get))
+    case _ => z
   }
 
-  def move(p: Project, pp: Project) = p.parent(pp).save()
+  def move(project: Project, parent: Project) = project.parent(parent).save()
 
-  def moveToRoot(p: Project) = p.parent(Empty).save()
+  def moveToRoot(project: Project) = project.parent(Empty).save()
 
-  def isEmpty(p: Project) = Task.findAll(By(Task.parent, p)).isEmpty && Project.findAll(By(Project.parent, p)).isEmpty
+  def isEmpty(project: Project) = Task.findAll(By(Task.parent, project)).isEmpty && Project.findAll(By(Project.parent, project)).isEmpty
 
-  def delete(p: Project) =
-    if (isEmpty(p)) p.delete_!
+  def delete(project: Project) =
+    if (isEmpty(project)) project.delete_!
     else throw new IllegalArgumentException("Projects with tasks or subprojects can not be deleted.")
 
 }

--- a/src/main/scala/code/service/ProjectService.scala
+++ b/src/main/scala/code/service/ProjectService.scala
@@ -4,17 +4,16 @@ package service
 import code.model.Project
 import code.model.Task
 import net.liftweb.mapper.By
-import net.liftweb.common.Empty
+import net.liftweb.common.{Box, Full, Empty}
 
 object ProjectService {
 
   def getDisplayName(project: Project): String = {
-    val parentProject = Project.findByKey(project.parent.get)
-    if (parentProject.isEmpty) {
-      project.name.get
-    } else {
-      getDisplayName(parentProject.get) + "-" + project.name
+    def loop(z: List[Project], box: Box[Project]): List[Project] = box match {
+      case Full(p) => loop(p :: z, Project.findByKey(p.parent.get))
+      case _ => z
     }
+    loop(Nil, Full(project)).map(_.name).mkString("-")
   }
 
   def move(what: Project, newParent: Project) = what.parent(newParent).save


### PR DESCRIPTION
This branch contains fixes for compiler warnings from issue #38. I also added some tests for all the functions in `ProjectService`. 

**The known defects of the test suite**:
- I had to call the `givenSomeProjectData` init function in each test, because the `DbSpec` is not works well with `FunSpec`.
- The test on `delete` function is not complete, because after deletion I can retrieve the deleted project from the db. I think the `DbSpec` is not commiting the changes.

**The known defects of the refactoring**:
- In the `getDisplayName` function I used tail recursion. I wanted to use some higher level abstraction to examine the project path. Also I am not sure it worth the investment to find that solution.
